### PR TITLE
Read Service Bus connection from env

### DIFF
--- a/ClientOrganizer.API/Configuration/Configuration.cs
+++ b/ClientOrganizer.API/Configuration/Configuration.cs
@@ -37,6 +37,15 @@ namespace ClientOrganizer.API.Configuration
             // Bus client and bus sender
             builder.Services.AddOptions<ServiceBusOptions>()
                 .Bind(builder.Configuration.GetSection("ServiceBus"))
+                .PostConfigure(options =>
+                {
+                    var serviceBusConnectionString = Environment.GetEnvironmentVariable("serviceBusConnectionString");
+                    if (string.IsNullOrWhiteSpace(serviceBusConnectionString))
+                    {
+                        throw new InvalidOperationException("Service Bus connection string not found in environment variables.");
+                    }
+                    options.ConnectionString = serviceBusConnectionString;
+                })
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
 

--- a/ClientOrganizer.FunctionApp/FinanceEmailFunction.cs
+++ b/ClientOrganizer.FunctionApp/FinanceEmailFunction.cs
@@ -27,7 +27,7 @@ namespace ClientOrganizer.FunctionApp
 
         [Function("FinanceEmailFunction")]
         public async Task Run(
-            [ServiceBusTrigger("%FinanceQueueName%", Connection = "ServiceBusConnection")] string queueMessage,
+            [ServiceBusTrigger("%FinanceQueueName%", Connection = "serviceBusConnectionString")] string queueMessage,
             FunctionContext context)
         {
             var log = context.GetLogger("FinanceEmailFunction");

--- a/ClientOrganizer.FunctionApp/Program.cs
+++ b/ClientOrganizer.FunctionApp/Program.cs
@@ -8,9 +8,12 @@ using ClientOrganizer.FunctionApp.Services;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
+var serviceBusConnectionString = Environment.GetEnvironmentVariable("serviceBusConnectionString")
+    ?? throw new InvalidOperationException("Service Bus connection string not found in environment variables.");
+
 builder.Services.AddAzureClients(azureBuilder =>
 {
-    azureBuilder.AddServiceBusClient(builder.Configuration["ServiceBusConnection"]);
+    azureBuilder.AddServiceBusClient(serviceBusConnectionString);
 });
 
 builder.Services.AddSingleton(sp =>


### PR DESCRIPTION
## Summary
- Source Service Bus connection strings from `serviceBusConnectionString` environment variable in API and Function App
- Update Service Bus trigger to use the same environment variable

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ae22fc0d8832eaae2098aead3d7fd