### PR TITLE
Use AsNoTracking for read-only service queries

### DIFF
--- a/ClientOrganizer.API/Services/ClientService.cs
+++ b/ClientOrganizer.API/Services/ClientService.cs
@@ -19,13 +19,17 @@ public class ClientService : IClientService
 
     public async Task<IEnumerable<ClientReadDto>> GetClientsAsync()
     {
-        var clients = await _dbContext.Clients.ToListAsync();
+        var clients = await _dbContext.Clients
+            .AsNoTracking()
+            .ToListAsync();
         return _mapper.Map<IEnumerable<ClientReadDto>>(clients);
     }
 
     public async Task<ClientReadDto?> GetClientByIdAsync(int id)
     {
-        var client = await _dbContext.Clients.FindAsync(id);
+        var client = await _dbContext.Clients
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id);
         return client is null ? null : _mapper.Map<ClientReadDto>(client);
     }
 

--- a/ClientOrganizer.API/Services/FinanceService.cs
+++ b/ClientOrganizer.API/Services/FinanceService.cs
@@ -24,6 +24,7 @@ public class FinanceService : IFinanceService
     {
         var records = await _dbContext.FinancialData
             .Where(f => f.ClientId == clientId)
+            .AsNoTracking()
             .ToListAsync();
 
         return _mapper.Map<IEnumerable<FinancialRecordReadDto>>(records);
@@ -31,13 +32,16 @@ public class FinanceService : IFinanceService
 
     public async Task<FinancialRecordReadDto?> GetByIdAsync(int id)
     {
-        var record = await _dbContext.FinancialData.FindAsync(id);
+        var record = await _dbContext.FinancialData
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == id);
         return record is null ? null : _mapper.Map<FinancialRecordReadDto>(record);
     }
 
     public async Task<FinancialRecordReadDto?> GetByClientMonthYearAsync(int clientId, int month, int year)
     {
         var record = await _dbContext.FinancialData
+            .AsNoTracking()
             .FirstOrDefaultAsync(f => f.ClientId == clientId && f.Month == month && f.Year == year);
         return record is null ? null : _mapper.Map<FinancialRecordReadDto>(record);
     }
@@ -76,7 +80,9 @@ public class FinanceService : IFinanceService
         if (record is null)
             return new FinanceServiceResult(FinanceServiceError.NotFound, null);
 
-        var client = await _dbContext.Clients.FindAsync(clientId);
+        var client = await _dbContext.Clients
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == clientId);
         if (client is null)
         {
             return new FinanceServiceResult(FinanceServiceError.NotFound, null);


### PR DESCRIPTION
## Summary
- avoid unnecessary entity tracking in ClientService list and lookup queries
- add AsNoTracking to FinanceService read-only retrievals
- use no-tracking when fetching client for finance updates

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b04c56994832eb0f4480ecaa4eacb