### PR TITLE
Bind SendGrid configuration to options with validation

### DIFF
--- a/ClientOrganizer.FunctionApp/Configuration/SendGridOptions.cs
+++ b/ClientOrganizer.FunctionApp/Configuration/SendGridOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClientOrganizer.FunctionApp.Configuration;
+
+public class SendGridOptions
+{
+    [Required]
+    public string ApiKey { get; set; } = string.Empty;
+
+    [Required]
+    public string FromEmail { get; set; } = string.Empty;
+}

--- a/ClientOrganizer.FunctionApp/FinanceEmailFunction.cs
+++ b/ClientOrganizer.FunctionApp/FinanceEmailFunction.cs
@@ -2,6 +2,9 @@ using ClientOrganizer.FunctionApp.Services;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using SendGrid;
+using ClientOrganizer.FunctionApp.Configuration;
+using Microsoft.Extensions.Options;
+using System;
 
 namespace ClientOrganizer.FunctionApp
 {
@@ -11,18 +14,24 @@ namespace ClientOrganizer.FunctionApp
         private readonly IEmailContentProvider _contentProvider;
         private readonly IQueueMessageParser _messageParser;
         private readonly ISendGridMessageFactory _messageFactory;
-        private readonly string _fromEmail = Environment.GetEnvironmentVariable("SendGridFromEmail")!;
+        private readonly string _fromEmail;
 
         public FinanceEmailFunction(
             SendGridClient sendGridClient,
             IEmailContentProvider contentProvider,
             IQueueMessageParser messageParser,
-            ISendGridMessageFactory messageFactory)
+            ISendGridMessageFactory messageFactory,
+            IOptions<SendGridOptions> sendGridOptions)
         {
             _sendGridClient = sendGridClient;
             _contentProvider = contentProvider;
             _messageParser = messageParser;
             _messageFactory = messageFactory;
+            _fromEmail = sendGridOptions.Value.FromEmail;
+            if (string.IsNullOrWhiteSpace(_fromEmail))
+            {
+                throw new InvalidOperationException("SendGrid FromEmail is not configured.");
+            }
         }
 
         [Function("FinanceEmailFunction")]


### PR DESCRIPTION
## Summary
- Centralize SendGrid settings with `SendGridOptions` (API key and from address)
- Bind and validate SendGrid options when configuring the function app
- Ensure `FinanceEmailFunction` uses options and throws when `FromEmail` is missing

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b04e3e2d4832ea57bb8690934dcbe